### PR TITLE
Init converters issue fixed for ruby 2.5

### DIFF
--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -38,6 +38,7 @@ module Csvlint
         ESCAPE_RE[@re_chars][@re_esc][str]
       end
 
+     if RUBY_VERSION < '2.5'
       # Optimization: Disable the CSV library's converters feature.
       # @see https://github.com/ruby/ruby/blob/v2_2_3/lib/csv.rb#L2100
       def init_converters(options, field_name = :converters)
@@ -46,6 +47,7 @@ module Csvlint
         options.delete(:unconverted_fields)
         options.delete(field_name)
       end
+     end
     end
 
     include Csvlint::ErrorCollector


### PR DESCRIPTION
Refer https://github.com/theodi/csvlint.rb/pull/217

This is a quick fix until the original project solves the issue. 